### PR TITLE
Set nulls for all possible arrays

### DIFF
--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -508,6 +508,8 @@ fn fixed_size_list_array_to_vector(
         }
     }
 
+    set_nulls_in_array_vector(array, out);
+
     Ok(())
 }
 
@@ -555,6 +557,7 @@ fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) -> Result
             }
         }
     }
+    set_nulls_in_struct_vector(array, out);
     Ok(())
 }
 
@@ -592,6 +595,24 @@ pub fn arrow_ffi_to_query_params(array: FFI_ArrowArray, schema: FFI_ArrowSchema)
 }
 
 fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
+    if let Some(nulls) = array.nulls() {
+        for (i, null) in nulls.into_iter().enumerate() {
+            if !null {
+                out_vector.set_null(i);
+            }
+        }
+    }
+}
+fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) {
+    if let Some(nulls) = array.nulls() {
+        for (i, null) in nulls.into_iter().enumerate() {
+            if !null {
+                out_vector.set_null(i);
+            }
+        }
+    }
+}
+fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -483,6 +483,7 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
         let length = array.value_length(i);
         out.set_entry(i, offset.as_(), length.as_());
     }
+    set_nulls_in_list_vector(array, out);
 
     Ok(())
 }
@@ -603,6 +604,7 @@ fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
         }
     }
 }
+
 fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
@@ -612,7 +614,18 @@ fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) 
         }
     }
 }
+
 fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector) {
+    if let Some(nulls) = array.nulls() {
+        for (i, null) in nulls.into_iter().enumerate() {
+            if !null {
+                out_vector.set_null(i);
+            }
+        }
+    }
+}
+
+fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -484,8 +484,6 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
         out.set_entry(i, offset.as_(), length.as_());
     }
 
-    set_nulls_in_list_vector(array, out);
-
     Ok(())
 }
 
@@ -606,15 +604,6 @@ fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
     }
 }
 fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) {
-    if let Some(nulls) = array.nulls() {
-        for (i, null) in nulls.into_iter().enumerate() {
-            if !null {
-                out_vector.set_null(i);
-            }
-        }
-    }
-}
-fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -508,8 +508,6 @@ fn fixed_size_list_array_to_vector(
         }
     }
 
-    set_nulls_in_array_vector(array, out);
-
     Ok(())
 }
 
@@ -557,7 +555,6 @@ fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) -> Result
             }
         }
     }
-    set_nulls_in_struct_vector(array, out);
     Ok(())
 }
 
@@ -595,24 +592,6 @@ pub fn arrow_ffi_to_query_params(array: FFI_ArrowArray, schema: FFI_ArrowSchema)
 }
 
 fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
-    if let Some(nulls) = array.nulls() {
-        for (i, null) in nulls.into_iter().enumerate() {
-            if !null {
-                out_vector.set_null(i);
-            }
-        }
-    }
-}
-fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) {
-    if let Some(nulls) = array.nulls() {
-        for (i, null) in nulls.into_iter().enumerate() {
-            if !null {
-                out_vector.set_null(i);
-            }
-        }
-    }
-}
-fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {

--- a/crates/duckdb/src/vtab/vector.rs
+++ b/crates/duckdb/src/vtab/vector.rs
@@ -173,6 +173,15 @@ impl ListVector {
         self.entries.as_mut_slice::<duckdb_list_entry>()[idx].length = length as u64;
     }
 
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.entries.ptr);
+            let idx = duckdb_vector_get_validity(self.entries.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
+    }
+
     /// Reserve the capacity for its child node.
     fn reserve(&self, capacity: usize) {
         unsafe {
@@ -221,6 +230,15 @@ impl ArrayVector {
     /// Set primitive data to the child node.
     pub fn set_child<T: Copy>(&self, data: &[T]) {
         self.child(data.len()).copy(data);
+    }
+
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.ptr);
+            let idx = duckdb_vector_get_validity(self.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
     }
 }
 
@@ -278,5 +296,14 @@ impl StructVector {
     pub fn num_children(&self) -> usize {
         let logical_type = self.logical_type();
         unsafe { duckdb_struct_type_child_count(logical_type.ptr) as usize }
+    }
+
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.ptr);
+            let idx = duckdb_vector_get_validity(self.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
     }
 }

--- a/crates/duckdb/src/vtab/vector.rs
+++ b/crates/duckdb/src/vtab/vector.rs
@@ -173,15 +173,6 @@ impl ListVector {
         self.entries.as_mut_slice::<duckdb_list_entry>()[idx].length = length as u64;
     }
 
-    /// Set row as null
-    pub fn set_null(&mut self, row: usize) {
-        unsafe {
-            duckdb_vector_ensure_validity_writable(self.entries.ptr);
-            let idx = duckdb_vector_get_validity(self.entries.ptr);
-            duckdb_validity_set_row_invalid(idx, row as u64);
-        }
-    }
-
     /// Reserve the capacity for its child node.
     fn reserve(&self, capacity: usize) {
         unsafe {

--- a/crates/duckdb/src/vtab/vector.rs
+++ b/crates/duckdb/src/vtab/vector.rs
@@ -173,6 +173,15 @@ impl ListVector {
         self.entries.as_mut_slice::<duckdb_list_entry>()[idx].length = length as u64;
     }
 
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.entries.ptr);
+            let idx = duckdb_vector_get_validity(self.entries.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
+    }
+
     /// Reserve the capacity for its child node.
     fn reserve(&self, capacity: usize) {
         unsafe {
@@ -190,7 +199,6 @@ impl ListVector {
 
 /// A array vector. (fixed-size list)
 pub struct ArrayVector {
-    /// ArrayVector does not own the vector pointer.
     ptr: duckdb_vector,
 }
 
@@ -235,7 +243,6 @@ impl ArrayVector {
 
 /// A struct vector.
 pub struct StructVector {
-    /// ListVector does not own the vector pointer.
     ptr: duckdb_vector,
 }
 

--- a/crates/duckdb/src/vtab/vector.rs
+++ b/crates/duckdb/src/vtab/vector.rs
@@ -222,15 +222,6 @@ impl ArrayVector {
     pub fn set_child<T: Copy>(&self, data: &[T]) {
         self.child(data.len()).copy(data);
     }
-
-    /// Set row as null
-    pub fn set_null(&mut self, row: usize) {
-        unsafe {
-            duckdb_vector_ensure_validity_writable(self.ptr);
-            let idx = duckdb_vector_get_validity(self.ptr);
-            duckdb_validity_set_row_invalid(idx, row as u64);
-        }
-    }
 }
 
 /// A struct vector.
@@ -287,14 +278,5 @@ impl StructVector {
     pub fn num_children(&self) -> usize {
         let logical_type = self.logical_type();
         unsafe { duckdb_struct_type_child_count(logical_type.ptr) as usize }
-    }
-
-    /// Set row as null
-    pub fn set_null(&mut self, row: usize) {
-        unsafe {
-            duckdb_vector_ensure_validity_writable(self.ptr);
-            let idx = duckdb_vector_get_validity(self.ptr);
-            duckdb_validity_set_row_invalid(idx, row as u64);
-        }
     }
 }

--- a/crates/duckdb/src/vtab/vector.rs
+++ b/crates/duckdb/src/vtab/vector.rs
@@ -222,6 +222,15 @@ impl ArrayVector {
     pub fn set_child<T: Copy>(&self, data: &[T]) {
         self.child(data.len()).copy(data);
     }
+
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.ptr);
+            let idx = duckdb_vector_get_validity(self.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
+    }
 }
 
 /// A struct vector.
@@ -278,5 +287,14 @@ impl StructVector {
     pub fn num_children(&self) -> usize {
         let logical_type = self.logical_type();
         unsafe { duckdb_struct_type_child_count(logical_type.ptr) as usize }
+    }
+
+    /// Set row as null
+    pub fn set_null(&mut self, row: usize) {
+        unsafe {
+            duckdb_vector_ensure_validity_writable(self.ptr);
+            let idx = duckdb_vector_get_validity(self.ptr);
+            duckdb_validity_set_row_invalid(idx, row as u64);
+        }
     }
 }


### PR DESCRIPTION
set nulls for all possible arrays.

This is needed to ensure data integrity when inserting data into duckdb accelerator in spice oss.