### PR TITLE
streaming arrow

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -1,5 +1,3 @@
-use arrow::datatypes::Schema;
-
 use super::{
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
     Statement,

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -30,8 +30,8 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     }
 }
 
-/// An handle for the resulting RecordBatch of a query.
-#[must_use = "Arrow stream "]
+/// An handle for the resulting RecordBatch of a query in streaming
+#[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
 pub struct ArrowStream<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
     pub(crate) schema: SchemaRef,

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -1,3 +1,5 @@
+use arrow::datatypes::Schema;
+
 use super::{
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
     Statement,
@@ -7,12 +9,24 @@ use super::{
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
+    pub(crate) schema: Option<SchemaRef>,
 }
 
 impl<'stmt> Arrow<'stmt> {
     #[inline]
     pub(crate) fn new(stmt: &'stmt Statement<'stmt>) -> Arrow<'stmt> {
-        Arrow { stmt: Some(stmt) }
+        Arrow {
+            stmt: Some(stmt),
+            schema: None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn new_with_schema(stmt: &'stmt Statement<'stmt>, schema: SchemaRef) -> Arrow<'stmt> {
+        Arrow {
+            stmt: Some(stmt),
+            schema: Some(schema),
+        }
     }
 
     /// return arrow schema
@@ -26,6 +40,10 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(RecordBatch::from(&self.stmt?.step()?))
+        if let Some(schema) = &self.schema {
+            Some(RecordBatch::from(&self.stmt?.stream_step(schema.clone())?))
+        } else {
+            Some(RecordBatch::from(&self.stmt?.step()?))
+        }
     }
 }

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -9,24 +9,12 @@ use super::{
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
-    pub(crate) schema: Option<SchemaRef>,
 }
 
 impl<'stmt> Arrow<'stmt> {
     #[inline]
     pub(crate) fn new(stmt: &'stmt Statement<'stmt>) -> Arrow<'stmt> {
-        Arrow {
-            stmt: Some(stmt),
-            schema: None,
-        }
-    }
-
-    #[inline]
-    pub(crate) fn new_with_schema(stmt: &'stmt Statement<'stmt>, schema: SchemaRef) -> Arrow<'stmt> {
-        Arrow {
-            stmt: Some(stmt),
-            schema: Some(schema),
-        }
+        Arrow { stmt: Some(stmt) }
     }
 
     /// return arrow schema
@@ -40,10 +28,37 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(schema) = &self.schema {
-            Some(RecordBatch::from(&self.stmt?.stream_step(schema.clone())?))
-        } else {
-            Some(RecordBatch::from(&self.stmt?.step()?))
+        Some(RecordBatch::from(&self.stmt?.step()?))
+    }
+}
+
+/// An handle for the resulting RecordBatch of a query.
+#[must_use = "Arrow stream "]
+pub struct ArrowStream<'stmt> {
+    pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
+    pub(crate) schema: SchemaRef,
+}
+
+impl<'stmt> ArrowStream<'stmt> {
+    #[inline]
+    pub(crate) fn new(stmt: &'stmt Statement<'stmt>, schema: SchemaRef) -> ArrowStream<'stmt> {
+        ArrowStream {
+            stmt: Some(stmt),
+            schema,
         }
+    }
+
+    /// return arrow schema
+    #[inline]
+    pub fn get_schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl<'stmt> Iterator for ArrowStream<'stmt> {
+    type Item = RecordBatch;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(RecordBatch::from(&self.stmt?.stream_step(self.get_schema())?))
     }
 }

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -3,7 +3,7 @@ use super::{
     Statement,
 };
 
-/// An handle for the resulting RecordBatch of a query.
+/// A handle for the resulting RecordBatch of a query.
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
@@ -30,7 +30,7 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     }
 }
 
-/// An handle for the resulting RecordBatch of a query in streaming
+/// A handle for the resulting RecordBatch of a query in streaming
 #[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
 pub struct ArrowStream<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -73,7 +73,7 @@ pub use crate::r2d2::DuckdbConnectionManager;
 pub use crate::{
     appender::Appender,
     appender_params::{appender_params_from_iter, AppenderParams, AppenderParamsFromIter},
-    arrow_batch::Arrow,
+    arrow_batch::{Arrow, ArrowStream},
     cache::CachedStatement,
     column::Column,
     config::{AccessMode, Config, DefaultNullOrder, DefaultOrder},

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CStr, ops::Deref, ptr, rc::Rc, sync::Arc};
 
 use arrow::{
-    array::{ArrowNativeTypeOp, StructArray},
+    array::StructArray,
     datatypes::{DataType, Schema, SchemaRef},
     ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema},
 };

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -1,10 +1,4 @@
-use std::{
-    ffi::CStr,
-    ops::Deref,
-    ptr::{self, null_mut},
-    rc::Rc,
-    sync::Arc,
-};
+use std::{ffi::CStr, ops::Deref, ptr, rc::Rc, sync::Arc};
 
 use arrow::{
     array::{ArrowNativeTypeOp, StructArray},
@@ -120,7 +114,7 @@ impl RawStatement {
 
     #[inline]
     pub fn streaming_step(&self, schema: SchemaRef) -> Option<StructArray> {
-        if let Some(mut result) = self.duckdb_result {
+        if let Some(result) = self.duckdb_result {
             unsafe {
                 let mut out = ffi::duckdb_stream_fetch_chunk(result);
 


### PR DESCRIPTION
This adds streaming support on duckdb. It requires passing an schema as there is no available method to fetch the schema without getting the arrow records for the entire query.