### PR TITLE
Add Utf8View & BinaryView to supported Arrow vtab types

### DIFF
--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -157,8 +157,8 @@ pub fn to_duckdb_type_id(data_type: &DataType) -> Result<LogicalTypeId, Box<dyn 
         DataType::Time64(_) => Time,
         DataType::Duration(_) => Interval,
         DataType::Interval(_) => Interval,
-        DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) => Blob,
-        DataType::Utf8 | DataType::LargeUtf8 => Varchar,
+        DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) | DataType::BinaryView => Blob,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Varchar,
         DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => List,
         DataType::Struct(_) => Struct,
         DataType::Union(_, _) => Union,
@@ -201,8 +201,10 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalTypeHandle,
         DataType::Boolean
         | DataType::Utf8
         | DataType::LargeUtf8
+        | DataType::Utf8View
         | DataType::Binary
         | DataType::LargeBinary
+        | DataType::BinaryView
         | DataType::FixedSizeBinary(_) => Ok(LogicalTypeHandle::from(to_duckdb_type_id(data_type)?)),
         dtype if dtype.is_primitive() => Ok(LogicalTypeHandle::from(to_duckdb_type_id(data_type)?)),
         _ => Err(format!(

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -572,8 +572,28 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
         DataType::Utf8 => {
             string_array_to_vector(as_string_array(value_array.as_ref()), &mut child);
         }
+        DataType::Utf8View => {
+            string_view_array_to_vector(
+                value_array
+                    .as_ref()
+                    .as_any()
+                    .downcast_ref::<StringViewArray>()
+                    .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to StringViewArray"))?,
+                &mut child,
+            );
+        }
         DataType::Binary => {
             binary_array_to_vector(as_generic_binary_array(value_array.as_ref()), &mut child);
+        }
+        DataType::BinaryView => {
+            binary_view_array_to_vector(
+                value_array
+                    .as_ref()
+                    .as_any()
+                    .downcast_ref::<BinaryViewArray>()
+                    .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to BinaryViewArray"))?,
+                &mut child,
+            );
         }
         _ => {
             return Err("Nested list is not supported yet.".into());


### PR DESCRIPTION
## 🗣 Description

Adds the `Utf8View` and `BinaryView` to the supported Arrow vtab types, to allow integration with DataFusion 43 which returns those types.
