### PR TITLE
bundle core_functions extension (#437)

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -125,6 +125,8 @@ mod build_bundled {
 
         let mut cfg = cc::Build::new();
 
+        add_extension(&mut cfg, &manifest, "core_functions", &mut cpp_files, &mut include_dirs);
+
         #[cfg(feature = "parquet")]
         add_extension(&mut cfg, &manifest, "parquet", &mut cpp_files, &mut include_dirs);
 

--- a/crates/libduckdb-sys/update_sources.py
+++ b/crates/libduckdb-sys/update_sources.py
@@ -16,7 +16,7 @@ SRC_DIR = os.path.join(SCRIPT_DIR, "src")
 
 # List of extensions' sources to grab. Technically, these sources will be compiled
 # but not included in the final build unless they're explicitly enabled.
-EXTENSIONS = ["parquet", "json"]
+EXTENSIONS = ["core_functions", "parquet", "json"]
 
 # Clear the duckdb directory
 try:


### PR DESCRIPTION
Bundle `core_functions` extension to fix `"core_functions.duckdb_extension" not found error ` on Linux

Similar to recent change in duckdb-rs https://github.com/duckdb/duckdb-rs/pull/437