### PR TITLE
v1.3.2; force DUCKDB_VERSION

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -154,6 +154,7 @@ mod build_bundled {
             .flag_if_supported("-std=c++11")
             .flag_if_supported("/utf-8")
             .flag_if_supported("/bigobj")
+            .flag_if_supported("-DDUCKDB_VERSION=\"1.3.2\"")
             .warnings(false)
             .flag_if_supported("-w");
 


### PR DESCRIPTION
## 🗣 Description

Sets `DUCKDB_VERSION` in `build.rs` so that we don't break the ability to install extensions. I would have used the `define` builder but it strips the quotes (which we need). 
