### PR TITLE
Set the DUCKDB_VERSION environment variable to 1.4.3 to download official extensions

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -138,6 +138,11 @@ mod build_bundled {
         cfg.define("DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT", "1");
         cfg.define("DUCKDB_EXTENSION_AUTOLOAD_DEFAULT", "1");
 
+        // Override the DuckDB version to ensure extension compatibility
+        // This makes the build download extensions from the official release path
+        // (extensions.duckdb.org/v1.4.3/...) instead of the dev git hash path
+        cfg.define("DUCKDB_VERSION", Some("v1.4.3"));
+
         // Since the manifest controls the set of files, we require it to be changed to know whether
         // to rebuild the project
         println!("cargo:rerun-if-changed={out_dir}/{lib_name}/manifest.json");


### PR DESCRIPTION
## 🗣 Description

Extension autoloading fails with HTTP 404 errors when using a forked DuckDB build:

> Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'httpfs':
> Failed to download extension "httpfs" at URL "http://extensions.duckdb.org/58e70bde3e/linux_amd64/httpfs.duckdb_extension.gz" (HTTP 404)

**Root Cause**
DuckDB generates extension download URLs based on the `DUCKDB_VERSION` string baked into the build. The URL path uses either:

- The version tag (e.g., v1.4.3) for release builds
- The git commit hash (e.g., 58e70bde3e) for development builds

A build is considered a "release" if DUCKDB_VERSION does not contain -dev.
When update_sources.py packages the DuckDB sources, it runs git describe to determine the version. If the submodule is checked out at a commit that is not exactly on a release tag, the version includes a -dev suffix (e.g., v1.4.2-dev569), causing DuckDB to use the git hash in extension URLs instead of the version tag.

The official extension repository only hosts extensions for release versions, so any URL containing a git hash will 404.