### PR TITLE
Reconcile Spice Arrow 58 state onto spiceai-58 (supersedes #36)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -152,7 +152,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -233,18 +233,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1307,12 +1307,6 @@ dependencies = [
  "rayon",
  "serde",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ duckdb = { version = "=1.10502.0", path = "crates/duckdb" }
 duckdb-loadable-macros = { version = "=1.10502.0", path = "crates/duckdb-loadable-macros" }
 libduckdb-sys = { version = "=1.10502.0", path = "crates/libduckdb-sys" }
 
-arrow = { version = "57", default-features = false }
+arrow = { version = "58", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 calamine = "0.28.0"
 cast = "0.3"


### PR DESCRIPTION
## Summary

Reconciles the Arrow-58 Spice fork state onto the \`spiceai-58\` version branch so it is cleanly mergeable. **This supersedes #36** (\`spiceai-58\` <- \`spiceai-58-patches\`), which is CONFLICTING.

This is the exact duckdb-rs state the Spice runtime is validated and building against (pinned rev \`db9fa02\`), plus a lockfile sync.

## Why #36 conflicts

#36's head \`spiceai-58-patches\` is the **old DuckDB-1.4.2-era** Spice patch set (2 commits: an Arrow-57 bump + \`register_arrow_scan_view\`). Its base \`spiceai-58\` was since **rebuilt on DuckDB 1.5.2** (upstream history merged in, then Arrow temporarily downgraded 58→57 for compatibility). The two share only an ancient merge-base (\`c9f5ff5\`), so re-applying the stale patch commits conflicts massively.

Critically, the one Spice-specific code patch — \`register_arrow_scan_view\` in \`crates/duckdb/src/arrow_scan.rs\` — is **already present in \`spiceai-58\`** (folded in via the upstream \`duckdb_arrow_scan\` support + Spice rebuild). The patch content in \`spiceai-58-patches\` is therefore fully superseded; the only thing it still needed to deliver was the Arrow-58 version bump.

## What this PR contains

\`lukim/duckdb-58-reconcile\` = \`spiceai-58\` + two clean commits:

1. \`db9fa02\` **Restore arrow 58 for the arrow-58 spiceai workspace** — undoes the temporary \`835faee\` Arrow-57 downgrade now that the workspace is on Arrow 58 (Cargo.toml: \`arrow = "57"\` → \`"58"\`). Arrow 57↔58 needed zero code changes for duckdb-rs.
2. \`829f066\` **Sync Cargo.lock to arrow 58.3.0** — \`db9fa02\` bumped the manifest but left \`Cargo.lock\` resolving arrow* at 57.3.1, so a standalone \`--locked\` build of the fork (and fork CI) would fail. Regenerated the 11 arrow* lock entries to 58.3.0.

The head is a **strict descendant of \`spiceai-58\`**, so the merge is a zero-conflict fast-forward. Net diff vs base: Cargo.toml (1 line) + Cargo.lock (arrow stack 57.3.1 → 58.3.0).

## Verification

\`cargo check -p duckdb --locked\` against the system DuckDB 1.5.3: compiles the full arrow 58.3.0 stack + the duckdb crate (incl. the \`register_arrow_scan_view\` FFI surface) cleanly — \`Finished\` in ~7s, zero errors/warnings.